### PR TITLE
Fix KCODE warnings on Ruby 1.9 or later.

### DIFF
--- a/api/admin_log.cgi
+++ b/api/admin_log.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: admin_log report=<report-id> user=<login> id=<log-id>
 #   ログを変更
@@ -10,7 +11,7 @@
 # Security:
 #   master.su に入っているユーザのみ実行可能
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/admin_runtest.cgi
+++ b/api/admin_runtest.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: admin_runtest report=<report-id> user=<login>
 #   自動テストを再実行
@@ -8,7 +9,7 @@
 # Security:
 #   master.su に入っているユーザのみ実行可能
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/admin_solved.cgi
+++ b/api/admin_solved.cgi
@@ -1,11 +1,12 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: admin_solved report=<report-id> user=<login> exercise=ex1,ex2,..,exN
 #   問いた問題を変更
 # Security:
 #   master.su に入っているユーザのみ実行可能
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/browse.cgi
+++ b/api/browse.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: browse report=<report-id> user=<login>
 #               [type={raw|highlight}] [path=.]
@@ -21,7 +22,7 @@
 #     - type=highlightならハイライトしたHTML(text/html)
 #   - pathがバイナリファイルを指すとき: 生ファイル(適切なMIMEタイプ)
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/comment.cgi
+++ b/api/comment.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage:
 #   comment report=<report-id> user=<login> action=<action> ...
@@ -29,7 +30,7 @@
 # Security:
 # Response:
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/master.cgi
+++ b/api/master.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: master [year] [user]
 #   基本設定を取得
@@ -11,7 +12,7 @@
 KEY = []
 OPTIONAL = [ :year, :user, :admin, :token ]
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/scheme.cgi
+++ b/api/scheme.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: scheme [type=<type>] [id=<id>] [record] [exercise]
 #   scheme.ymlのデータを取得
@@ -12,7 +13,7 @@ KEY = [ :id, :type, :name, :update ]
 OPTIONAL = [ :record, :exercise ]
 FILTER = [ :id, :type, ]
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/template.cgi
+++ b/api/template.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: template [type=<type>] [links] [requirements]
 #   template.ymlのデータを取得
@@ -10,7 +11,7 @@
 KEY = [ :institute, :title, :subtitle, ]
 OPTIONAL = [ :links, :requirements, ]
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/test_result.cgi
+++ b/api/test_result.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: test_result report=<report-id> user=<login>
 #   自動テストの結果を取得
@@ -9,7 +10,7 @@
 #   master.su に入っていないユーザに関しては user オプションによらず
 #   ログイン名が remote_user の情報のみ取得可能
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/api/user.cgi
+++ b/api/user.cgi
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 # Usage: user [user=<login>] [type={info|status}]
 #             [status={solved|record}] [log] [report=<report-id>]
@@ -16,7 +17,7 @@
 #   master.su に入っていないユーザに関しては user オプションによらず
 #   ログイン名が remote_user の情報のみ取得可能
 
-$KCODE='UTF8'
+$KCODE='UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/post/post.cgi
+++ b/post/post.cgi
@@ -1,5 +1,7 @@
 #! /usr/bin/env ruby
-$KCODE = 'UTF8'
+# -*- coding: utf-8 -*-
+
+$KCODE = 'UTF8' if RUBY_VERSION < '1.9.0'
 
 $:.unshift('./lib')
 

--- a/sandbox/tester.cgi
+++ b/sandbox/tester.cgi
@@ -1,5 +1,7 @@
 #! /usr/bin/env ruby
-$KCODE = 'UTF8'
+# -*- coding: utf-8 -*-
+
+$KCODE = 'UTF8' if RUBY_VERSION < '1.9.0'
 
 require 'tempfile'
 require 'tmpdir'


### PR DESCRIPTION
Ruby 1.9以降で実行する場合に出力される警告ログを出力されないようにします。

参考: http://doc.ruby-lang.org/ja/search/module:Kernel/query:$KCODE/
