### PR TITLE
Fixed a bug of initial_submit.

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -132,7 +132,7 @@ class App
       return nil unless File.exist?(fname)
       yaml = Log.new(fname, true).latest(:data)
       # add timestamp of initial submit
-      yaml['initial_submit'] = Log.new(fname, true).oldest(:data)['timestamp']
+      yaml['initial_submit'] = Log.new(fname, true).oldest(:data)['id']
       src = Report::Source::Post.new(yaml, optional)
     else
       yaml = file(:data) rescue {}


### PR DESCRIPTION
初回提出日時に関する次のバグを修正しました。

バグ：
提出したファイルが１つのときに、テストの再実行をすると初回提出日時がテストを実行した日時になる

原因：
初回提出日時として参照している log.yml の timestamp がテストの再実行によって書き換わってしまうため

対処：
timestamp ではなく id を参照するようにした
