### PR TITLE
Remove [] operator override of the Pathname class

### DIFF
--- a/api/admin_log.cgi
+++ b/api/admin_log.cgi
@@ -56,7 +56,7 @@ begin
   data['log'] = data_log
 
   unless data.empty?
-    log_file = (App::KADAI + report_id + user)[App::FILES[:log]]
+    log_file = App::KADAI + report_id + user + App::FILES[:log]
     Log.new(log_file).transaction do |log|
       helper.exit_with_bad_request if log.latest(:data)['id'] != log_id
       log.update(:data, log_id, data)

--- a/api/admin_solved.cgi
+++ b/api/admin_solved.cgi
@@ -39,7 +39,7 @@ helper.exit_with_bad_request unless exercises
 exercises = exercises.split(',').sort{|a,b| a.to_ex <=> b.to_ex}
 
 begin
-  log_file = (App::KADAI + report_id + user)[App::FILES[:log]]
+  log_file = App::KADAI + report_id + user + App::FILES[:log]
   Log.new(log_file).transaction do |log|
     log.latest(:data)['report'] = exercises
   end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -14,14 +14,6 @@ require 'kwalify'
 
 require 'logger'
 
-class Pathname
-  def [](*paths)
-    loc = self
-    loc = loc + paths.shift() while paths.length > 0
-    return loc.to_s
-  end
-end
-
 class App
   def self.find_base(dir)
     e = Pathname($0).expand_path.parent.to_enum(:ascend)
@@ -37,17 +29,17 @@ class App
   SCRIPT = find_base(:script)
 
   FILES = {
-    :master          => CONFIG['master.yml'],
-    :master_schema   => SCHEMA['master.yml'],
-    :local           => CONFIG['local.yml'],
-    :local_schema    => SCHEMA['local.yml'],
-    :scheme          => CONFIG['scheme.yml'],
-    :template        => CONFIG['template.yml'],
-    :data            => DB['data.yml'],
-    :log             => 'log.yml',
-    :build           => TESTER['build.rb'],
-    :sandbox         => TESTER['test.rb'],
-    :test_script     => SCRIPT['test'],
+    :master        => CONFIG + 'master.yml',
+    :master_schema => SCHEMA + 'master.yml',
+    :local         => CONFIG + 'local.yml',
+    :local_schema  => SCHEMA + 'local.yml',
+    :scheme        => CONFIG + 'scheme.yml',
+    :template      => CONFIG + 'template.yml',
+    :data          => DB + 'data.yml',
+    :log           => 'log.yml',
+    :build         => TESTER + 'build.rb',
+    :sandbox       => TESTER + 'test.rb',
+    :test_script   => SCRIPT + 'test',
   }
 
   LOGGER_LEVEL = {
@@ -161,7 +153,7 @@ class App
     optional << :log if option[:log]
 
     if (file(:scheme)['scheme'].find{|r| r['id']==id} || {})['type'] == 'post'
-      fname = KADAI[id, u, FILES[:log]]
+      fname = KADAI + id + u + FILES[:log]
       return nil unless File.exist?(fname)
       yaml = Log.new(fname, true).latest(:data)
       # add timestamp of initial submit
@@ -195,7 +187,7 @@ class App
       :size => proc{ StringScanner.new(`du -sk "#{dir}"`).scan(/\d+/).to_i },
       :entries => proc do
         if (dir+App::FILES[:log]).exist?
-          Log.new(dir[App::FILES[:log]]).size
+          Log.new(dir + App::FILES[:log]).size
         else
           Pathname.new(dir).children.select(&:directory?).size
         end

--- a/post/post.cgi
+++ b/post/post.cgi
@@ -56,7 +56,7 @@ rep_defined = rep_schemes.any?{|r| r['id'] == rep_id}
 raise ArgumentError, (err[:invalid] % rep_id) unless rep_defined
 
 USER_DIR = app.user_dir(rep_id)
-log_file = USER_DIR[App::FILES[:log]]
+log_file = USER_DIR + App::FILES[:log]
 
 begin
   begin

--- a/script/test
+++ b/script/test
@@ -38,7 +38,7 @@ dir[:test]   = dir[:user] + 'test'
 # sudo su www-data -c "command args..."
 Dir.chdir(oldwd){ Permission.ensure_writable(dir[:user].to_s) }
 
-log_file = dir[:user][App::FILES[:log]]
+log_file = dir[:user] + App::FILES[:log]
 log = if $argv[:id]
         Log.new(log_file, true).retrieve(:data, $argv[:id])
       else
@@ -50,7 +50,7 @@ cmd = {}
 
 # ../test/build.rb report_id user post
 cmd[:build] = "#{App::FILES[:build]} '#{report_id}' '#{user}' '#{time}'"
-cmd[:build] = "#{cmd[:build]} > /dev/null 2>#{dir[:user]['build_fatal.log']}"
+cmd[:build] = "#{cmd[:build]} > /dev/null 2>#{dir[:user] + 'build_fatal.log'}"
 
 # ../test/test.rb report_id user post
 cmd[:test] = "#{App::FILES[:sandbox]} '#{report_id}' '#{user}' '#{time}'"

--- a/test/build.rb
+++ b/test/build.rb
@@ -28,7 +28,7 @@ dir[:target] = dir[:test] + 'src'
 dir[:build]  = App::BUILD
 
 files = {
-  :log    => dir[:user][App::FILES[:log]],
+  :log    => dir[:user] + App::FILES[:log],
 }
 
 yml = {}
@@ -82,7 +82,7 @@ Dir.each_leaf(dir[:target].to_s, File::FNM_DOTMATCH) do |f|
 end
 
 # make input file
-input = dir[:test][conf[:test]['input']]
+input = dir[:test] + conf[:test]['input']
 FileUtils.rm(input) if File.exist?(input)
 open(input, 'w'){|io| exes.each{|x| io.puts(x)}}
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -30,7 +30,7 @@ dir[:user]   = App::KADAI + report_id + user
 dir[:test]   = dir[:user] + 'test'
 
 files = {
-  :log    => dir[:user][App::FILES[:log]],
+  :log    => dir[:user] + App::FILES[:log],
   :scheme => App::FILES[:scheme],
 }
 


### PR DESCRIPTION
削除の理由はいろいろあるんですが、一言で言えば演算子オーバーライドのデメリットに対して可読性が特にあがってないという点でしょうか。
