### PR TITLE
Fix incorrect require order

### DIFF
--- a/post/post.cgi
+++ b/post/post.cgi
@@ -7,13 +7,12 @@ require 'tempfile'
 require 'tmpdir'
 require 'time'
 require 'kconv'
-require 'zip'
 
 require_relative '../lib/cgi_helper'
 require_relative '../lib/app'
 require_relative '../lib/report/exercise'
 require_relative '../lib/log'
-
+require 'zip'
 
 class Pathname
   def toutf8() return to_s.toutf8 end


### PR DESCRIPTION
app.rb が bundler/setup を require してるから app のあとに zip を require すれば ok みたいな書き方していいんですかね。