### PR TITLE
Recover independence of sandbox cgi

### DIFF
--- a/sandbox/tester.cgi
+++ b/sandbox/tester.cgi
@@ -44,16 +44,8 @@ begin
   file.close
 
   # extract archive file
-  begin
-    Zip::File.open(path) do |zip_file|
-      zip_file.each do |entry|
-        entry.extract("#{src_dir}/#{entry.name}")
-      end
-    end
-  rescue => e
-    app.logger.error("tester.cgi failed to unzip \"#{path}\" with \"#{e.to_s}\"")
-    raise RuntimeError, :unzip unless res
-  end
+  res = system("env 7z x -o#{dir} #{path} > /dev/null 2>&1")
+  raise RuntimeError, :unzip unless res
 
   # command line argument
   args = []


### PR DESCRIPTION
sandbox用のスクリプトがautomataのライブラリに依存していたので元に戻しました。