### PR TITLE
Modified git ignores the contents of db directory except .gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 build
 config/*.yml
-db/data.yml
 .htaccess
 .htdigest
-db/kadai
 script/setup/passwd
+
+db
+!db/.gitkeep
 
 node_modules
 bower_components


### PR DESCRIPTION
db はサーバーがデータディレクトリとして使うためのものなので中身無視でいいはずです。
元々も kadai と data.yml は無視するようになってましたが、他にも色々（ログの出力ファイルとか）置きたいので。