### PR TITLE
Remove pry-byebug.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :development, :test do
   gem 'rake'
   gem 'rr', require: false
   gem 'test-unit'
-  gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (3.5.1)
-      columnize (~> 0.8)
-      debugger-linecache (~> 1.2)
-      slop (~> 3.6)
-    coderay (1.1.0)
-    columnize (0.9.0)
     crass (1.0.1)
-    debugger-linecache (1.2.0)
     json (1.8.2)
     kramdown (1.6.0)
     kwalify (0.7.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    method_source (0.8.2)
     mime-types (2.4.3)
     mini_portile (0.6.2)
     nokogiri (1.6.6.2)
@@ -22,13 +14,6 @@ GEM
     nokogumbo (1.2.0)
       nokogiri
     power_assert (0.2.3)
-    pry (0.10.1)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    pry-byebug (3.0.1)
-      byebug (~> 3.4)
-      pry (~> 0.10)
     rack (1.6.0)
     rake (10.4.2)
     rr (1.1.2)
@@ -38,7 +23,6 @@ GEM
       nokogiri (>= 1.4.4)
       nokogumbo (= 1.2.0)
     shared-mime-info (0.2.5)
-    slop (3.6.0)
     test-unit (3.0.9)
       power_assert
 
@@ -51,7 +35,6 @@ DEPENDENCIES
   kramdown
   kwalify
   mail
-  pry-byebug
   rack
   rake
   rr


### PR DESCRIPTION
Ruby 1.9 には対応していなかったので。