### PR TITLE
add_user 関連

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,33 +9,47 @@ Rake::TestTask.new do |t|
 end
 
 class App
-  def add_user_with_passwd(name,ruby,login,email)
-    add_user({
+  def add_user_with_passwd(name, ruby, login, email)
+    u = add_user(
       'name'  => name,
       'ruby'  => ruby,
       'login' => login,
       'email' => email
-    })
-    set_passwd(login, login)
+    )
+    if u
+      puts "Add user #{login}."
+      set_passwd(login, login)
+      return true
+    end
+    false
   end
 end
 
 task 'dummy' do
-  puts 'Add dummy users.'
-
   app = App.new
 
-  app.add_user_with_passwd('松村 史郎', 'まつむら しろう', 'matsumura', 'shirou@example.com')
-  app.add_user_with_passwd('柏原 高明', 'かしわら たかあき', 'takaaki', 'kashiwara@example.com')
-  app.add_user_with_passwd('戸谷 鬼怒子', 'とたに きぬこ', 'kinuko', 'totani@example.com')
-  app.add_user_with_passwd('山口 雪絵', 'やまぐち ゆきえ', 'yukie',
-    'yama.yama-guti@example.com')
-  app.add_user_with_passwd('篠原 慎太郎', 'しのはら しんたろう', 'sin', 'sin@example.com')
-  app.add_user_with_passwd('佐久間 ひろよ', 'さくま ひろよ', '1029224532', 'hiro@example.com')
-  app.add_user_with_passwd('伴 守', 'ばん まもる', '7427466391', 'ban@example.com')
-  app.add_user_with_passwd('Li Mei Kung', '', 'kung', 'LiMeiKung@example.com')
-  app.add_user_with_passwd('William M. Mickle', '', 'fuleat', 'WilliamMMickle@example.com')
-  app.add_user_with_passwd('Kate J. Roberts', '', 'Somrat', 'KateJRoberts@example.com')
+  def app.su?
+    true
+  end
+
+  dummy_users = [
+    ['松村 史郎', 'まつむら しろう', 'matsumura', 'shirou@example.com'],
+    ['柏原 高明', 'かしわら たかあき', 'takaaki', 'kashiwara@example.com'],
+    ['戸谷 鬼怒子', 'とたに きぬこ', 'kinuko', 'totani@example.com'],
+    ['山口 雪絵', 'やまぐち ゆきえ', 'yukie', 'yama.yama-guti@example.com'],
+    ['篠原 慎太郎', 'しのはら しんたろう', 'sin', 'sin@example.com'],
+    ['佐久間 ひろよ', 'さくま ひろよ', '1029224532', 'hiro@example.com'],
+    ['伴 守', 'ばん まもる', '7427466391', 'ban@example.com'],
+    ['Li Mei Kung', '', 'kung', 'LiMeiKung@example.com'],
+    ['William M. Mickle', '', 'fuleat', 'WilliamMMickle@example.com'],
+    ['Kate J. Roberts', '', 'Somrat', 'KateJRoberts@example.com']
+  ]
+
+  cnt = 0
+  dummy_users.map do |u|
+    cnt += 1 if app.add_user_with_passwd(u[0], u[1], u[2], u[3])
+  end
+  puts "Added #{cnt} users."
 end
 
 task 'htaccess' do

--- a/lib/account/register.rb
+++ b/lib/account/register.rb
@@ -27,12 +27,14 @@ module Account
         email = helper.params['email']
         name  = helper.params['name']
         ruby  = helper.params['ruby']
-        login = helper.params['login'].to_s
+        login = helper.params['login']
 
         # Validates arguments.
-        if email.empty? || name.empty? || ruby.empty? || login !~ /[0-9]{10}/
+        if email.nil? || name.nil? || ruby.nil? || login.nil?
           fail InvalidArguments
         end
+        login = login.to_s
+        fail InvalidArguments if login !~ /[0-9]{10}/
 
         # Checks whether the email address or the login are already used or not.
         if app.users.any? { |u| u.email == email || u.real_login == login }
@@ -55,6 +57,7 @@ module Account
         return helper.redirect(URL + '#invalidarguments')
       rescue => e
         app.logger.error(e.to_s)
+        app.logger.error(e.backtrace)
         return helper.redirect(URL + '#failed')
       end
     end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -60,9 +60,8 @@ class App
     return @logger
   end
 
-  def user()
-    @user ||= conf[:master, :user] || @remote_user || ENV['USER']
-    return @user
+  def user
+    @remote_user
   end
 
   def su?(u=nil)


### PR DESCRIPTION
- App#user が ```conf[:master, :user] || @remote_user || ENV['USER']``` だったのを ```@remote_user``` だけにしました。
- dummy タスクが 非 su ユーザで実行すると重複登録してしまうバグを直しました (fix #176) 。
- account/register.rb が rack に対応してなかったので直しました。