### PR TITLE
Improve user interfaces

### DIFF
--- a/js/record2/answer_view.js
+++ b/js/record2/answer_view.js
@@ -14,10 +14,12 @@ var Solved = React.createClass({
             );
         });
         return (
-                <ul>
+                <div>
                 <h3>解答済み</h3>
+                <ul>
                 {solved}
                 </ul>
+                </div>
         );
     }
 });
@@ -37,10 +39,12 @@ var Unsolved = React.createClass({
         }
 
         return (
-                <ul>
+                <div>
                 <h3>未回答</h3>
+                <ul>
                 {unsolved}
                 </ul>
+                </div>
         );
     }
 });

--- a/js/record2/detail_list.js
+++ b/js/record2/detail_list.js
@@ -43,30 +43,15 @@ var OptionalCell = React.createClass({
 var ReportList = React.createClass({
     mixins: [Router.Navigation],
 
-    updateStatus: function(token, report) {
-        $.get('../api/user.cgi',
-              {
-                  type: 'status',
-                  user: token,
-                  report: report,
-              },
-              function(result) {
-                  this.setState({
-                      users: this.state.users.map(function(user) {
-                          if (user.token === token) {
-                              user.report[report].status = result[0].report[report].status;
-                          }
-                          return user;
-                      })
-                  });
-              }.bind(this));
-    },
-
-    getInitialState: function() {
-        return {
-            users: [],
-            users_init: false,
-        };
+    updateStatus: function(token, report, status) {
+        this.setState({
+            users: this.state.users.map(function(user) {
+                if (user.token === token) {
+                    user.report[report].status = status;
+                }
+                return user;
+            })
+        });
     },
 
     componentDidMount: function() {
@@ -80,6 +65,9 @@ var ReportList = React.createClass({
         $.get('../api/user.cgi',
               data,
               function(users) {
+                  this.setState({
+                      users: users,
+                  });
                   var tokens = users.map(function(user) { return user.token; });
                   $.get('../api/comment.cgi',
                         {
@@ -99,8 +87,7 @@ var ReportList = React.createClass({
                                 user['report'][this.props.scheme.id]['comment'] = comments[key];
                             }, this);
                             this.setState({
-                                users: users,
-                                users_init: true,
+                                users: users
                             });
                         }.bind(this));
               }.bind(this));
@@ -112,65 +99,67 @@ var ReportList = React.createClass({
                     <th className={r.field}>{r.label}</th>
             );
         });
-        var users = this.state.users.map(function(user) {
-            var tds = this.props.scheme.record.map(function(r) {
-                if (r.field === 'name') {
-                    var unreads = ['report', this.props.scheme.id, 'comment', 'unreads'].reduce(function(r, k) {
-                        if (!r[k]) r[k] = {};
-                        return r[k];
-                    }, user);
-                    if (unreads > 0) {
-                        unreads = (<div className="unread">{unreads}</div>);
+        var users;
+        if (this.state) {
+            users = this.state.users.map(function(user) {
+                var tds = this.props.scheme.record.map(function(r) {
+                    if (r.field === 'name') {
+                        var unreads = ['report', this.props.scheme.id, 'comment', 'unreads'].reduce(function(r, k) {
+                            if (!r[k]) r[k] = {};
+                            return r[k];
+                        }, user);
+                        if (unreads > 0) {
+                            unreads = (<div className="unread">{unreads}</div>);
+                        }
+                        return (<td className="name">{unreads}{user.name}</td>);
+                    } else if (r.field === 'status') {
+                        return (<StatusCell user={user} report={this.props.scheme.id} admin={this.props.admin} updateStatus={this.updateStatus}/>);
+                    } else if (/^optional/.test(r.field)) {
+                        var answered = ['report', this.props.scheme.id, 'optional'].reduce(function(r, k) {
+                            if (typeof r[k] === 'undefined') r[k] = {};
+                            return r[k];
+                        }, user);
+                        if (!Array.isArray(answered)) answered = [];
+                        return (<OptionalCell name={r.field} answered={answered}/>);
+                    } else if (r.field === 'unsolved') {
+                        var unsolved = ['report', this.props.scheme.id, 'unsolved'].reduce(function(r, k) {
+                            if (typeof r[k] === 'undefined') r[k] = {};
+                            return r[k];
+                        }, user);
+                        if (!Array.isArray(unsolved)) unsolved = [];
+                        var str = unsolved.map(function(l) {
+                            var r = l[0];
+                            if (l[1] > 1) r += 'のうち残り' + l[1] + '問';
+                            return r;
+                        }).join(', ');
+                        return (<td className="unsolved">{str}</td>);
+                    } else if (r.field === 'test') {
+                        var test = ['report', this.props.scheme.id, 'log', 'test'].reduce(function(r, k) {
+                            if (!r[k]) r[k] = {};
+                            return r[k];
+                        }, user);
+                        var str;
+                        if ('passed' in test && 'number' in test) {
+                            str = test.passed + '/' + test.number;
+                        }
+                        return (<td className="test">{str}</td>);
+                    } else {
+                        return (<td></td>);
                     }
-                    return (<td className="name">{unreads}{user.name}</td>);
-                } else if (r.field === 'status') {
-                    return (<StatusCell user={user} report={this.props.scheme.id} admin={this.props.admin} updateStatus={this.updateStatus}/>);
-                } else if (/^optional/.test(r.field)) {
-                    var answered = ['report', this.props.scheme.id, 'optional'].reduce(function(r, k) {
-                        if (typeof r[k] === 'undefined') r[k] = {};
-                        return r[k];
-                    }, user);
-                    if (!Array.isArray(answered)) answered = [];
-                    return (<OptionalCell name={r.field} answered={answered}/>);
-                } else if (r.field === 'unsolved') {
-                    var unsolved = ['report', this.props.scheme.id, 'unsolved'].reduce(function(r, k) {
-                        if (typeof r[k] === 'undefined') r[k] = {};
-                        return r[k];
-                    }, user);
-                    if (!Array.isArray(unsolved)) unsolved = [];
-                    var str = unsolved.map(function(l) {
-                        var r = l[0];
-                        if (l[1] > 1) r += 'のうち残り' + l[1] + '問';
-                        return r;
-                    }).join(', ');
-                    return (<td className="unsolved">{str}</td>);
-                } else if (r.field === 'test') {
-                    var test = ['report', this.props.scheme.id, 'log', 'test'].reduce(function(r, k) {
-                        if (!r[k]) r[k] = {};
-                        return r[k];
-                    }, user);
-                    var str;
-                    if ('passed' in test && 'number' in test) {
-                        str = test.passed + '/' + test.number;
-                    }
-                    return (<td className="test">{str}</td>);
-                } else {
-                    return (<td></td>);
-                }
+                }.bind(this));
+                var transTo = function() {
+                    this.transitionTo('user', {
+                        token: user.token,
+                        report: this.props.scheme.id,
+                    });
+                }.bind(this);
+                return (
+                        <tr className="selectable" onClick={transTo}>{tds}</tr>
+                );
             }.bind(this));
-            var transTo = function() {
-                this.transitionTo('user', {
-                    token: user.token,
-                    report: this.props.scheme.id,
-                });
-            }.bind(this);
-            return (
-                    <tr className="selectable" onClick={transTo}>{tds}</tr>
-            );
-        }.bind(this));
-        if (!this.state.users_init) {
+        } else {
             users = (
-                    <tr><td colSpan={ths.length}><img src="./loading.gif"/></td></tr>
+                    <tr><td colSpan={ths.length}><img src="../image/loading.gif"/></td></tr>
             );
         }
         return (

--- a/js/record2/record.js
+++ b/js/record2/record.js
@@ -83,17 +83,19 @@ var Record = React.createClass({
                 );
             }
         }
+        var institute = this.state.template.institute
+            ? (<h2 id="institute">{this.state.template.institute}</h2>)
+            : null;
+        var title = this.state.template.title
+            ? (<h1 id="title">{this.state.template.title}</h1>)
+            : null;
+        var subtitle = this.state.template.subtitle
+            ? (<h2 id="subtitle">{this.state.template.subtitle}</h2>)
+            : null;
         return (
                 <div>
                 <div id="article">
-                <h2 id="institute">{this.state.template.institute}</h2>
-                <h1 id="title">{this.state.template.title}</h1>
-                <h2 id="subtitle">{this.state.template.subtitle}</h2>
-                <ul>
-                <li>提出が済んだ場合は, 「提出済」と記載されます</li>
-                <li>提出内容に不備がある場合は, 「要再提出」と記載されます</li>
-                <li>提出しても, チェックが完了するまでは「確認中」と記載されます</li>
-                </ul>
+                {institute}{title}{subtitle}
                 <div id="record">
                 <div id="view_switch">
                 表示:<ul>

--- a/js/record2/status_header.js
+++ b/js/record2/status_header.js
@@ -25,17 +25,24 @@ module.exports = React.createClass({
             var className = 'status_tabbar_button';
             var tabName = this.getPath().split('/')[3];
             if (!tabName) tabName = 'log';
+            var params = {
+                token: this.getParams().token,
+                report: this.getParams().report
+            };
             if (tab.path === tabName) {
-                className += ' selected';
+                return (
+                        <li className={className + ' selected'} key={tab.path}>
+                        <Link to={tab.path} params={params}
+                              onClick={this.props.reload}>{tab.name}</Link>
+                        </li>
+                );
+            } else {
+                return (
+                        <li className={className} key={tab.path}>
+                        <Link to={tab.path} params={params}>{tab.name}</Link>
+                        </li>
+                );
             }
-            return (
-                    <li className={className} key={tab.path}>
-                    <Link to={tab.path} params={{
-                        token: this.getParams().token,
-                        report: this.getParams().report,
-                    }}>{tab.name}</Link>
-                    </li>
-            );
         }.bind(this));
         return (
                 <div className="status_header">

--- a/js/record2/summary_list.js
+++ b/js/record2/summary_list.js
@@ -4,23 +4,15 @@ var $ = require('jquery');
 var StatusCell = require('./status_cell.js');
 
 module.exports = React.createClass({
-    updateStatus: function(token, report) {
-        $.get('../api/user.cgi',
-              {
-                  type: 'status',
-                  user: token,
-                  report: report,
-              },
-              function(result) {
-                  this.setState({
-                      users: this.state.users.map(function(user) {
-                          if (user.token === token) {
-                              user.report[report].status = result[0].report[report].status;
-                          }
-                          return user;
-                      })
-                  });
-              }.bind(this));
+    updateStatus: function(token, report, status) {
+        this.setState({
+            users: this.state.users.map(function(user) {
+                if (user.token === token) {
+                    user.report[report].status = status;
+                }
+                return user;
+            })
+        });
     },
 
     componentDidMount: function() {
@@ -31,6 +23,11 @@ module.exports = React.createClass({
         if (this.props.filtered) data.filter = true;
         $.get('../api/user.cgi', data,
               function(users) {
+                  if (this.isMounted()) {
+                      this.setState({
+                          users: users
+                      });
+                  }
                   var tokens = users.map(function(user) { return user.token; });
                   this.props.scheme.forEach(function(s) {
                       $.get('../api/comment.cgi',
@@ -61,8 +58,6 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        if (!this.state) return (<img src="../image/loading.gif"/>);
-
         var scheme = this.props.scheme.map(function(s) {
             return {
                 id: s.id,
@@ -77,18 +72,25 @@ module.exports = React.createClass({
             );
         });
         if (ths.length > 0) ths.unshift (<th>名前</th>);
-        var users = this.state.users.map(function(user) {
-            var kadais = scheme.map(function(s) {
-                var unreads = ['report', s.id, 'comment', 'unreads'].reduce(function(r, k) {
-                    if (!r[k]) r[k] = {};
-                    return r[k];
-                }, user);
-                return (<StatusCell user={user} report={s.id} isButton={true} admin={this.props.admin} updateStatus={this.updateStatus} unRead={unreads} isSelected={this.props.report === s.id}/>);
+        var users;
+        if (this.state) {
+            users = this.state.users.map(function(user) {
+                var kadais = scheme.map(function(s) {
+                    var unreads = ['report', s.id, 'comment', 'unreads'].reduce(function(r, k) {
+                        if (!r[k]) r[k] = {};
+                        return r[k];
+                    }, user);
+                    return (<StatusCell user={user} report={s.id} isButton={true} admin={this.props.admin} updateStatus={this.updateStatus} unRead={unreads} isSelected={this.props.report === s.id}/>);
+                }.bind(this));
+                return (
+                        <tr key={user.token}><td className="name">{user.name}</td>{kadais}</tr>
+                );
             }.bind(this));
-            return (
-                    <tr key={user.token}><td className="name">{user.name}</td>{kadais}</tr>
+        } else {
+            users = (
+                    <tr><td colSpan={ths.length}><img src="../image/loading.gif"/></td></tr>
             );
-        }.bind(this));
+        }
         return (
                 <table className="record">
                 <thead>

--- a/js/record2/user.js
+++ b/js/record2/user.js
@@ -14,6 +14,19 @@ var StatusHeader = require('./status_header.js');
 var User = React.createClass({
     mixins: [Router.State],
 
+    reloadView: function(e)  {
+        e.preventDefault();
+        this.setState({
+            counter: this.state.counter + 1
+        });
+    },
+
+    getInitialState: function() {
+        return {
+            counter: 0
+        };
+    },
+
     render: function() {
         var token = this.getParams().token;
         var report = this.getParams().report;
@@ -22,8 +35,8 @@ var User = React.createClass({
                 <div>
                 <SummaryList token={token} report={report} admin={this.props.admin} scheme={this.props.scheme}/>
                 <div className="status_window">
-                <StatusHeader/>
-                <RouteHandler token={token} report={report} admin={this.props.admin} key={token + report}/>
+                <StatusHeader reload={this.reloadView}/>
+                <RouteHandler token={token} report={report} admin={this.props.admin} key={token + report + this.state.counter}/>
                 </div>
                 </div>
         );


### PR DESCRIPTION
* 提出状況編集にローディング画像を追加
* 提出状況編集でcgiが成功を返した場合、信用して再度ステータスを取りに行かずに表示を更新するように変更
* 未読コメント状況の取得完了前にユーザ一覧を先に表示するように変更
* スペースを取っていたあんまり情報量のない説明文を削除
* 表示中のタブをクリックすることでタブの中身を再読み込みできるように変更
* 何箇所かレイアウトの崩れていた部分を修正