### PR TITLE
Use sourcemap.

### DIFF
--- a/gulp/reactify.js
+++ b/gulp/reactify.js
@@ -3,6 +3,8 @@ var browserify = require('browserify');
 var source = require('vinyl-source-stream');
 var watchify = require('watchify');
 var error = require('./error');
+var argv = require('yargs').argv;
+var debug = !!(argv.debug);
 
 module.exports = function(entries, dest, isWatch) {
     var compiled_msg = 'compiled '
@@ -12,7 +14,8 @@ module.exports = function(entries, dest, isWatch) {
         + ': ';
     var opt = {
         entries: entries,
-        transform: ['reactify']
+        transform: ['reactify'],
+        debug: debug
     };
     return function() {
         var bundler;

--- a/package.json
+++ b/package.json
@@ -17,19 +17,20 @@
   },
   "homepage": "https://github.com/SoftwareFoundationGroupAtKyotoU/automata",
   "devDependencies": {
-    "watchify": "^2.4.0",
     "browserify": "^9.0.3",
     "gulp": "^3.8.11",
     "gulp-concat": "^2.5.2",
-    "gulp-uglify": "^1.1.0",
     "gulp-notify": "^2.2.0",
-    "reactify": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0",
-    "lodash": "^3.5.0",
+    "gulp-uglify": "^1.1.0",
     "jquery": "^2.1.3",
     "jquery.cookie": "^1.4.1",
+    "lodash": "^3.5.0",
     "react": "^0.12.2",
-    "react-router": "^0.12.4"
+    "react-router": "^0.12.4",
+    "reactify": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^2.4.0",
+    "yargs": "^3.6.0"
   },
   "dependencies": {},
   "browserify": {


### PR DESCRIPTION
ビルド結果のJSにsourcemapをつけるようにしました。
sourcemapをつけることで、JS中のエラーがどこで発生したかを簡単に知ることができるようになります。

例えば、次の画像のような感じで、
![sourcemapの例](http://i.gyazo.com/cfcd3efcfa33f6da49a440e251da4766.png)
ビルドする前のどのファイルでエラーが起きてるのかわかる感じです。

それと、ビルド結果をminifyするようにしました。
sourcemapがあるので、デバッグが大変になることはないはずです。

また、これに伴ってビルド時間が伸びています。
大体手元では 8s -> 30s って感じです。
割りと遅くなってるので、悲しい感じです。