### PR TITLE
Fix Applet view for new js

### DIFF
--- a/js/record/file_view.js
+++ b/js/record/file_view.js
@@ -18,7 +18,7 @@ var FileEntry = (function() {
             e.preventDefault();
 
             var p = this.props;
-            if (p.entry.type === 'bin') return;
+            if (p.entry.type === 'bin' && p.entry.name.indexOf('.class') < 0) return;
 
             p.open(p.path+'/'+p.entry.name, p.entry.type);
         },
@@ -201,7 +201,7 @@ var FileView = (function() {
         },
 
         open: function(path, type) {
-            if (type === 'bin') return;
+            if (type === 'bin' && path.indexOf('.class') < 0) return;
 
             this.browseAPI(path, function(res) {
                 if (type === 'dir') {

--- a/lib/api/browse.rb
+++ b/lib/api/browse.rb
@@ -44,7 +44,7 @@ module API
       return helper.bad_request unless helper.params['report']
       report_id = helper.params['report']
 
-      path = Rack::Utils.unescape(helper.params['path'] || '.')
+      path = helper.params['path'] || '.'
       dir_user = App::KADAI + report_id + user
       log_file = dir_user + App::FILES[:log]
       return helper.not_found unless [dir_user, log_file].all?(&:exist?)


### PR DESCRIPTION
- 新しいjsでAppletが動くようにしました

- browse.cgiでpathが二重にdecodeされているようなので直しました。
(Rack::Utils#parse_nested_query でdecodeされている模様)