### PR TITLE
Mail configuration

### DIFF
--- a/config/example/master.yml
+++ b/config/example/master.yml
@@ -11,12 +11,12 @@ authn:
   admin: "automata@example.com"
 
 mail:
-  :address: "smtp.example.com"
-  :port: 587
-  :domain: "example.com"
-  :authentication: "plain"
-  :user_name: "username"
-  :password: "password"
+  address: "smtp.example.com"
+  port: 587
+  domain: "example.com"
+  authentication: "plain"
+  user_name: "username"
+  password: "password"
 
 
 record:

--- a/config/example/master.yml
+++ b/config/example/master.yml
@@ -10,6 +10,15 @@ authn:
   realm: "realm"
   admin: "automata@example.com"
 
+mail:
+  :address: "smtp.example.com"
+  :port: 587
+  :domain: "example.com"
+  :authentication: "plain"
+  :user_name: "username"
+  :password: "password"
+
+
 record:
   show_login: false
   open: false

--- a/config/schema/master.yml
+++ b/config/schema/master.yml
@@ -50,6 +50,29 @@ mapping:
         type: str
         required: yes
 
+  "mail":
+    type: map
+    required: no
+    mapping:
+     "addres":
+       type: str
+       required: no
+     "port":
+       type: int
+       required: no
+     "domain":
+       type: str
+       required: no
+     "authentication":
+       type: str
+       required: no
+     "user_name":
+       type: str
+       required: no
+     "password":
+       type: str
+       reqruied: no
+
   "record":
     type: map
     required: yes

--- a/lib/account/register.rb
+++ b/lib/account/register.rb
@@ -126,6 +126,9 @@ module Account
         body    "ページに戻って，次のトークンを入力してください．\n\n#{token}"
       end
       mail.charset = 'utf-8'
+      mail_options = Conf.new[:master, :mail]
+      p mail_options
+      mail.delivery_method(:smtp, mail_options)
       mail.deliver
 
       Haml::Engine.new(page).render do

--- a/lib/account/register.rb
+++ b/lib/account/register.rb
@@ -126,7 +126,7 @@ module Account
         body    "ページに戻って，次のトークンを入力してください．\n\n#{token}"
       end
       mail.charset = 'utf-8'
-      mail_options = Conf.new[:master, :mail]
+      mail_options = Hash[ Conf.new[:master, :mail].map{|k,v| [k.to_sym, v] } ]
       mail.delivery_method(:smtp, mail_options)
       mail.deliver
 

--- a/lib/account/register.rb
+++ b/lib/account/register.rb
@@ -127,7 +127,6 @@ module Account
       end
       mail.charset = 'utf-8'
       mail_options = Conf.new[:master, :mail]
-      p mail_options
       mail.delivery_method(:smtp, mail_options)
       mail.deliver
 

--- a/lib/reset.rb
+++ b/lib/reset.rb
@@ -35,6 +35,8 @@ class App
     end
 
     mail.charset = 'utf-8'
+    mail_options = Conf.new[:master, :mail]
+    mail.delivery_method(:smtp, mail_options)
     mail.deliver
   end
 end

--- a/lib/reset.rb
+++ b/lib/reset.rb
@@ -35,7 +35,7 @@ class App
     end
 
     mail.charset = 'utf-8'
-    mail_options = Conf.new[:master, :mail]
+    mail_options = Hash[ Conf.new[:master, :mail].map{|k,v| [k.to_sym, v] } ]
     mail.delivery_method(:smtp, mail_options)
     mail.deliver
   end


### PR DESCRIPTION
Fix #220 .

メールサーバを設定できるようにしました。
config/master.yml に
```
mail:
  :address: "smtp.example.com"
  :port: 587
  :domain: "example.com"
  :authentication: "plain"
  :user_name: "user_name"
  :password: "password"
```
という設定を追加すれば、そのサーバを使って送信できるようにしました。

正確に問題を理解できてるかわからないので、指摘の方あればどんどんお願いします。
