### PR TITLE
Return 'Forbidden' as a status code when user is not found in admin apis

### DIFF
--- a/lib/api/admin_interact.rb
+++ b/lib/api/admin_interact.rb
@@ -26,7 +26,7 @@ module API
 
       # resolve real login name in case user id is a token
       user = app.user_from_token(user)
-      return helper.bad_request unless user
+      return helper.forbidden unless user
 
       # report ID must be specified
       report_id = helper.params['report']

--- a/lib/api/admin_log.rb
+++ b/lib/api/admin_log.rb
@@ -30,7 +30,7 @@ module API
 
       # resolve real login name in case user id is a token
       user = app.user_from_token(user)
-      return helper.bad_request unless user
+      return helper.forbidden unless user
 
       # report ID must be specified
       report_id = helper.params['report']

--- a/lib/api/admin_runtest.rb
+++ b/lib/api/admin_runtest.rb
@@ -26,7 +26,7 @@ module API
 
       # resolve real login name in case user id is a token
       user = app.user_from_token(user)
-      return helper.bad_request unless user
+      return helper.forbidden unless user
 
       # report ID must be specified
       report_id = helper.params['report']

--- a/lib/api/admin_solved.rb
+++ b/lib/api/admin_solved.rb
@@ -24,7 +24,7 @@ module API
 
       # resolve real login name in case user id is a token
       user = app.user_from_token(user)
-      return helper.bad_request unless user
+      return helper.forbidden unless user
 
       # report ID must be specified
       report_id = helper.params['report']

--- a/lib/api/admin_user.rb
+++ b/lib/api/admin_user.rb
@@ -24,7 +24,7 @@ module API
 
       token = helper.params['user'] || ''
       user = app.user_from_token(token)
-      return helper.bad_request("Unknown user: #{token}") if user.nil?
+      return helper.forbidden unless user
 
       method = helper.params['method'] || ''
       case method.intern


### PR DESCRIPTION
admin系API で user 情報がとれないときは Forbidden を返すようにしました．
```lib/api/admin_user.rb``` ではメッセージを出してましたが Forbidden だしいらないかと思い消しました．
