### PR TITLE
Disable cache of ajax call

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -60,6 +60,7 @@ var call = function() {
         method: p.method,
         url:    api(p.api),
         data:   p.data,
+        cache:  false,
         error:  function(jqXHR, status) {
             jsonpFailure(status || 'request',
                          api(p.api)+(p.data ? '?'+$.param(p.data) : ''));


### PR DESCRIPTION
#263 の原因はキャッシュが効いているせいだと思います。
とりあえず`jquery.ajax`のパラメータに`cache: false`を追加しました。

以前のシステムでもキャッシュを効かせないためにタイムスタンプをリクエストパラメータに追加していたように記憶しています。