### PR TITLE
Syntax highlighting for code blocks in comments.

### DIFF
--- a/js/record/comment_view.js
+++ b/js/record/comment_view.js
@@ -8,6 +8,7 @@ var RouteHandler = Router.RouteHandler;
 var api = require('../api');
 
 var CommentForm = require('./comment_form.js');
+var Highlight = require('./highlight.js');
 
 var ACL_MESSAGE_FOR_ALL      = "全員に公開";
 var ACL_MESSAGE_FOR_USER     = "提出者に公開";
@@ -159,8 +160,9 @@ var Comment = React.createClass({
             default:
                 comment_box = (
                     <div className="form">
-                        <div className="message"
-                             dangerouslySetInnerHTML={{ __html: this.props.comment.content }}/>
+                        <Highlight className="message">
+                            {this.props.comment.content}
+                        </Highlight>
                     </div>
                 );
                 break;

--- a/js/record/highlight.js
+++ b/js/record/highlight.js
@@ -1,0 +1,31 @@
+var hljs = require('highlight.js');
+var React = require('react');
+
+var Highlight = React.createClass({
+    getDefaultProps: function() {
+        return {
+            className: ""
+        };
+    },
+    componentDidMount: function () {
+        this.highlightCode();
+    },
+    componentDidUpdate: function () {
+        this.highlightCode();
+    },
+    highlightCode: function () {
+        var node = this.getDOMNode();
+        var codes = node.querySelectorAll('pre code');
+        for (var i = 0; i < codes.length; i = i+1) {
+            hljs.highlightBlock(codes[i]);
+        }
+    },
+    render: function() {
+        return (
+            <div dangerouslySetInnerHTML={{__html: this.props.children}}
+                 className={this.props.className}></div>
+        );
+    }
+});
+
+module.exports = Highlight;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-if": "^1.2.5",
     "gulp-notify": "^2.2.0",
     "gulp-uglify": "^1.1.0",
+    "highlight.js": "^8.5.0",
     "jquery": "^2.1.3",
     "jquery.cookie": "^1.4.1",
     "lodash": "^3.5.0",

--- a/public/record/index.html
+++ b/public/record/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="../css/comment.css">
     <link rel="stylesheet" href="../css/navigator.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/styles/github.min.css">
   </head>
   <body>
     <div id="article">


### PR DESCRIPTION
markdown記法で書かれたコメント中のコードブロックをsyntax highlightするようにしました。
highlight.jsを使っています。

highlightのスタイルは record/index.html で呼んでいるスタイルファイルを変更することで変えられます。
とりあえず github スタイルにしていますが、議論のあるところだと思います。