### PR TITLE
Specify character code for vim outputs

### DIFF
--- a/lib/api/browse.rb
+++ b/lib/api/browse.rb
@@ -115,7 +115,7 @@ module API
         result = Open3.popen3("#{vimcmd} #{Shellwords.escape(path.realpath.to_s)}",
                               { chdir: dir.to_s }) do |i, o, e, t|
           i.close
-          o.read
+          o.read.force_encoding('utf-8')
         end
         return helper.json_response({'type' => 'txt', 'body' => result})
       elsif '.class' == path.extname && 'highlight' == helper.params['type']


### PR DESCRIPTION
Fix #291 vimは悪くなかった。
Encoding.default_externalがUS_ASCIIだったせいでioで読み込んだ文字列についてるエンコーディング情報がUS_ASCIIになっていた（文字列のデータ自体はUTF8になっている）のが原因でした。