### PR TITLE
Remove hyperlink of comment edit button when editing

### DIFF
--- a/js/record/comment_view.js
+++ b/js/record/comment_view.js
@@ -210,9 +210,7 @@ var Comment = React.createClass({
                 } else {
                     style.color = '#9a9';
                     return (
-                        <a key={i} style={style} title={p.title}>
-                            <i className={icon}/>
-                        </a>
+                        <i className={icon} style={style}/>
                     );
                 }
             }.bind(this));

--- a/public/css/default.css
+++ b/public/css/default.css
@@ -393,6 +393,9 @@ ul.comments > li.private {
    margin-left: 0.5em;
    text-decoration: none;
 }
+.comments div.meta .edit > i {
+   margin-left: 0.5em;
+}
 .comments div.meta .date,
 .comments div.meta .acl {
    font-size: 60%;


### PR DESCRIPTION
コメントの編集中とかにグレーアウトしていた編集ボタンの類が実はクリックできていたのをクリックできないように修正しました。
ちなみにグレーアウトしている状態でクリックするとrecord/に飛んでいたようです。