### PR TITLE
Fix unintended reloading at FileView

### DIFF
--- a/js/record/file_view.js
+++ b/js/record/file_view.js
@@ -271,7 +271,8 @@ var FileView = (function() {
         },
 
         componentWillReceiveProps: function() {
-            this.open(_.result(this.getParams(), 'splat', ''));
+            var path = _.result(this.getParams(), 'splat', '');
+            if (this.state.path !== path) this.open(path);
         },
 
         render: function() {


### PR DESCRIPTION
FileViewのpropsが更新されるたびに見ているファイルが再読み込みされていたのを修正しました。
FileViewを開いているときに「担当学生のみ」のチェックボックスをON/OFFすると挙動がわかると思います。