### PR TITLE
Force encoding of file_name to be UTF-8 in browse.rb

### DIFF
--- a/lib/api/browse.rb
+++ b/lib/api/browse.rb
@@ -159,8 +159,8 @@ module API
           <pre>
             <applet
               code="#{File.basename(path.to_s, '.*')}"
-              codebase="#{codebase_from_root}"
-              #{libs.empty? ? '' : 'archive="' + libs.join(',') + '"'}
+              codebase="#{codebase_from_root}
+              #{libs.empty? ? '' : '"archive=' + libs.join(',') + '"'}
               width="#{width}"
               height="#{height}"
               >

--- a/lib/api/browse.rb
+++ b/lib/api/browse.rb
@@ -76,7 +76,7 @@ module API
             type = MIME.check(f.to_s).media_type == 'text' ? 'txt' : 'bin'
           end
           {
-            'name' => f.basename.to_s,
+            'name' => f.basename.to_s.force_encoding('utf-8'),
             'type' => type,
             'size' => f.size,
             'time' => f.mtime.iso8601
@@ -159,8 +159,8 @@ module API
           <pre>
             <applet
               code="#{File.basename(path.to_s, '.*')}"
-              codebase="#{codebase_from_root}
-              #{libs.empty? ? '' : '"archive=' + libs.join(',') + '"'}
+              codebase="#{codebase_from_root}"
+              #{libs.empty? ? '' : 'archive="' + libs.join(',') + '"'}
               width="#{width}"
               height="#{height}"
               >


### PR DESCRIPTION
何故か日本語名ファイルがあると落ちるので。
post.rbで提出時にUTF-8に直しているように見えるのですが…。