### PR TITLE
Fix unnecessary error message on FileView

### DIFF
--- a/js/record/file_view.js
+++ b/js/record/file_view.js
@@ -214,8 +214,16 @@ var FileView = (function() {
                 path: path
             });
             api.get(
-                { api: 'browse', data: data.clone().assign({ type: 'highlight' }).value() },
-                { api: 'browse', data: data.clone().assign({ type: 'raw' }).value() }
+                {
+                    api: 'browse',
+                    data: data.clone().assign({ type: 'highlight' }).value(),
+                    ownError: true
+                },
+                {
+                    api: 'browse',
+                    data: data.clone().assign({ type: 'raw' }).value(),
+                    ownError: true
+                }
             ).done(function(result, rawContent) {
                 var newState = {
                     path: path,


### PR DESCRIPTION
ファイルビューで404になったときに必要のないエラーメッセージがページ上に表示されるのを削除しました。