### PR TITLE
Enable caching on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+cache: bundler
+sudo: false
 
 rvm:
   - 1.9.3


### PR DESCRIPTION
Travis CI で bundle install のキャッシュが効くようにしました。
テストが早くはじまるようにもなったようです。

参考
1. http://docs.travis-ci.com/user/caching/
2. http://docs.travis-ci.com/user/workers/container-based-infrastructure/ 