### PR TITLE
Fix a bug in post.rb.

### DIFF
--- a/lib/api/post.rb
+++ b/lib/api/post.rb
@@ -90,7 +90,7 @@ module API
       lift_dir(app, rep_id, ignore, src_dir)
 
       # clean entries
-      Find.find(src_dir) do |f|
+      Find.find(src_dir.to_s) do |f|
         next if File.directory?(f)
         FileUtils.rm(f) if f =~ /#{ignore}/
       end


### PR DESCRIPTION
post.rb の 93 行目でエラーが起きていて、src_dir が Pathname になっているが、Pathname には encoding というメソッドが存在しないのでエラーになっている

とりあえず to_s を付けて対処した