### PR TITLE
Bugfix about how to escape 'path' parameter.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ class User
     )
     if u
       puts "Add user #{login}."
-      self.set_passwd(login, login, Conf.new)
+      self.set_passwd(login, login)
       return true
     end
     false

--- a/config.ru
+++ b/config.ru
@@ -67,8 +67,8 @@ map base_path do
 
   use Rack::Rewrite do
     # path is included as a query parameter
-    rewrite %r{^(.*)/browse/([^/]+)/([^/]+)/(.+)$},
-            '$1/api/browse.cgi?user=$2&report=$3$4',
+    rewrite %r{^(.*)/browse/([^/]+)/([^/]+)/([^?]+).*$},
+            '$1/api/browse.cgi?user=$2&report=$3&path=$4',
             if: proc { |env| env['QUERY_STRING'] =~ /(?:^|&)path=/ }
     # path is included in uri but not as a query parameter
     rewrite %r{^(.*)/browse/([^/]+)/([^/]+)/(.+)$},

--- a/js/record/file_view.js
+++ b/js/record/file_view.js
@@ -364,15 +364,17 @@ var FileView = (function() {
 FileView.encodePath = function(path) {
     return [
         [ '&', '%26' ],
-        [ '\\?', '%3F' ]
+        [ '\\?', '%3F' ],
+        [ '\\+', '%2B' ]
     ].reduce(function(r, x) {
         return r.replace(new RegExp(x[0], 'g'), x[1]);
     }, encodeURI(path));
 };
 
 FileView.rawPath = function(user, report, path) {
-    var epath = FileView.encodePath(path);
-    pathname = '/browse/'+user+'/'+report+'/'+epath;
+    var myepath = FileView.encodePath(path);
+    pathname = '/browse/'+user+'/'+report+'/'+myepath;
+    var epath = encodeURIComponent(path)
     var param = path != epath ? ('?path=' + epath) : '';
     return api.root + pathname + param;
 };

--- a/js/record/file_view.js
+++ b/js/record/file_view.js
@@ -363,19 +363,17 @@ var FileView = (function() {
 
 FileView.encodePath = function(path) {
     return [
-        [ '&', '%26' ],
-        [ '\\?', '%3F' ],
-        [ '\\+', '%2B' ]
+        [ '%2F', '/' ]
     ].reduce(function(r, x) {
         return r.replace(new RegExp(x[0], 'g'), x[1]);
-    }, encodeURI(path));
+    }, encodeURIComponent(path));
 };
 
 FileView.rawPath = function(user, report, path) {
-    var myepath = FileView.encodePath(path);
-    pathname = '/browse/'+user+'/'+report+'/'+myepath;
-    var epath = encodeURIComponent(path)
-    var param = path != epath ? ('?path=' + epath) : '';
+    var epath = FileView.encodePath(path);
+    pathname = '/browse/'+user+'/'+report+'/'+epath;
+    var epath_param = encodeURIComponent(path)
+    var param = path != epath_param ? ('?path=' + epath_param) : '';
     return api.root + pathname + param;
 };
 

--- a/lib/browse/applet.rb
+++ b/lib/browse/applet.rb
@@ -2,6 +2,16 @@
 
 module Browse
   class Applet
+    def encode_path(path)
+      return [
+        [ '&', '%26' ],
+        [ '?', '%3F' ],
+        [ '+', '%2B' ]
+      ].inject(path){
+        |p, x| p.sub(x[0],x[1])
+      }
+    end
+    
     def html(root, path, user, report_id, conf)
       # applet tag consists of five attributes, 'code', 'codebase', 'archive', 'height' and 'width'
       # 'code' is a name of main class
@@ -34,7 +44,7 @@ module Browse
       applet_html = <<"APPLET"
       <applet
         code="#{File.basename(path.to_s, '.*')}"
-        codebase="#{codebase_from_root}"
+        codebase="#{encode_path(codebase_from_root)}"
         #{libs.empty? ? '' : 'archive="' + libs.join(',') + '"'}
         width="#{width}"
         height="#{height}"

--- a/lib/browse/applet.rb
+++ b/lib/browse/applet.rb
@@ -2,15 +2,6 @@
 
 module Browse
   class Applet
-    def encode_path(path)
-      return [
-        [ '&', '%26' ],
-        [ '?', '%3F' ],
-        [ '+', '%2B' ]
-      ].inject(path){
-        |p, x| p.sub(x[0],x[1])
-      }
-    end
     
     def html(root, path, user, report_id, conf)
       # applet tag consists of five attributes, 'code', 'codebase', 'archive', 'height' and 'width'
@@ -28,6 +19,8 @@ module Browse
          path.parent
         ].reduce {|dir,sub| dir+sub}
 
+      encoded_codebase = URI.escape(codebase_from_root.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")).gsub('%2F', '/')
+
       archive_path = root + 'jar'
       libs = conf['java_library']
       if libs.nil? || libs.empty?
@@ -44,7 +37,7 @@ module Browse
       applet_html = <<"APPLET"
       <applet
         code="#{File.basename(path.to_s, '.*')}"
-        codebase="#{encode_path(codebase_from_root)}"
+        codebase="#{encoded_codebase}"
         #{libs.empty? ? '' : 'archive="' + libs.join(',') + '"'}
         width="#{width}"
         height="#{height}"

--- a/public/browse/.htaccess
+++ b/public/browse/.htaccess
@@ -1,7 +1,9 @@
+# AllowEncodedSlashes must be On in VirtualHost setting.
 RewriteEngine on
+RewriteBase /
 RewriteRule ^.*$ %{REQUEST_URI} [C,DPI]
 RewriteCond %{QUERY_STRING} (?:^|&)path=
-RewriteRule ^(.*?)/browse/([^/]+)/([^/]+)/.+$ $1/api/browse.cgi?user=$2&report=$3 [L,QSA]
+RewriteRule ^/(.*?)/browse/([^/]+)/([^/]+)/.+$ $1/api/browse.cgi?user=$2&report=$3 [B,L,QSA]
 RewriteCond %{QUERY_STRING} !(?:^|&)path=
-RewriteRule ^(.*?)/browse/([^/]+)/([^/]+)/(.+)$ $1/api/browse.cgi?user=$2&report=$3&path=$4 [L]
+RewriteRule ^/(.*?)/browse/([^/]+)/([^/]+)/(.+)$ $1/api/browse.cgi?user=$2&report=$3&path=$4 [B,L]
 RewriteRule ^(.*)$ $1 [R=404]


### PR DESCRIPTION
uriのpathパラメータが正しくescapeされるようにしました．以下の影響があります．
- `+`や`&`付きpathに対して，「直接開く」が正しく動作する
- `+`や`&`付きディレクトリ以下のappletが読み込まれる

前者はconfig.ruとfile_view.jsのバグ．後者の解決方法は，rackとcgiの場合で異なっています．
- rackだと，applet tagの方でescapeしてやればよかった
- apacheの場合はrewrite engineでBフラグを付けてescapeする必要あり．さらにVirtualHostに`AllowEncodedSlashes On`を足す必要がある．