### PR TITLE
Fix problem about encoding of file name

### DIFF
--- a/lib/api/browse.rb
+++ b/lib/api/browse.rb
@@ -2,10 +2,10 @@
 
 require 'shellwords'
 require 'time'
-require 'shared-mime-info'
 require 'mime-types'
 require 'open3'
 
+require_relative '../shared-mime-info_ext'
 require_relative '../syspath'
 require_relative '../conf'
 require_relative '../app'
@@ -139,7 +139,7 @@ module API
 
     def find_browse_conf(app, path)
       path = path.to_s
-      (app.conf[:master, :browse] || {}).find{|k,v| path.to_s =~ /#{v['file']}/}
+      (app.conf[:master, :browse] || {}).find{|k,v| path =~ /#{v['file']}/}
     end
   end
 end

--- a/lib/api/post.rb
+++ b/lib/api/post.rb
@@ -85,13 +85,16 @@ module API
       ignore = ignore || '(?!.*)'
       ignore = '(?:'+ignore.join('|')+')' if ignore.is_a?(Array)
 
+      # convert file names to utf8
+      entries2utf8(src_dir)
+
       # lift directories
       lift_dir(rep_id, ignore, src_dir)
 
       # clean entries
       Find.find(src_dir.to_s) do |f|
         next if File.directory?(f)
-        FileUtils.rm(f) if f =~ /#{ignore}/
+        FileUtils.rm(f) if f.to_s =~ /#{ignore}/
       end
 
       # check requirements
@@ -104,9 +107,6 @@ module API
         FileUtils.rm_rf(src_dir.parent.to_s)
         fail ERR[:prerequisite]
       end
-
-      # convert file names to utf8
-      entries2utf8(src_dir)
 
       # solved exercises
       exs = helper.params['ex']
@@ -142,7 +142,7 @@ module API
     private
 
     def entries2utf8(path)
-      path.children do |e|
+      path.children.each do |e|
         entries2utf8(e) if e.directory?
         utf8 = e.to_s.toutf8
         e.rename(utf8) if utf8 != e.to_s

--- a/lib/shared-mime-info_ext.rb
+++ b/lib/shared-mime-info_ext.rb
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Avoid fnmatch bug.
+# See [http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/47069].
+require 'shared-mime-info'
+
+if RUBY_VERSION < '2.0.0'
+  module MIME
+    def check_globs(filename)
+      basename = File.basename(filename)
+      utf8_patterns = @globs.each_key.map{ |pattern| pattern.dup.encode("utf-8")}
+      found = utf8_patterns.select { |pattern| File.fnmatch pattern, basename }
+
+      if found.empty?
+        downcase_basename = basename.downcase
+        found = utf8_patterns.select { |pattern|
+          File.fnmatch pattern, downcase_basename
+        }
+      end
+
+      @globs[found.max]
+    end
+    module_function :check_globs
+  end
+end


### PR DESCRIPTION
- ファイル提出時にファイル名がUTF-8にエンコードされていなかった問題の解決
- 古いfnmatchのバグ潰し (cf. http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/47069)