### PR TITLE
Fix the problem that diff-view doesn't work as cgi.

### DIFF
--- a/lib/api/diff.rb
+++ b/lib/api/diff.rb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+require 'shellwords'
+require 'cgi'
 require 'time'
 require 'open3'
 


### PR DESCRIPTION
#397 のbug fix.
cgiとして動かした場合，モジュールのrequireが不足してエラーを起こすので，修正です．