### PR TITLE
Fix the result view continue showing a loading image

### DIFF
--- a/js/record/result_view.js
+++ b/js/record/result_view.js
@@ -5,7 +5,7 @@ var Loading = require('../loading');
 var Status = require('./status');
 
 function isPassed(t) {
-    if (typeof t !== 'string') t = t.result;
+    if (typeof t !== 'string') t = "result" in t ? t.result : "NG";
     return t.match(/^\s*ok\s*/i);
 }
 


### PR DESCRIPTION
The result view has been showing a loading image even if a server
returns a response.  This is because the view read an undefined
property of the response and failed.

This fix add check whether the property exists before reading.

たぶんサーバーのレスポンス`result`プロパティがないのは正常な動作な気がするのでjs側で場合分けするのが妥当かなと思った